### PR TITLE
Specify artifactory url to resolve dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,9 @@ apply plugin: 'maven-publish'
 repositories {
     mavenLocal()
     mavenCentral()
+    maven {
+        url "http://artifactory.strongloop.com:8081/artifactory/repo/"
+    }
 }
 
 android {


### PR DESCRIPTION
Jenkins build is not able to resolve dependencies from artifactory. Trying it out by explicitly specifying the artifactory url.
