### PR TITLE
Fix inclusion of strong-remoting-android in dist

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,30 +36,35 @@ android {
     }
 }
 
+configurations {
+    includeJavadocs
+    includeSources
+}
+
 dependencies {
     compile 'org.atteo:evo-inflector:1.0.1'
-    compile 'com.strongloop:strong-remoting-android:0.1.0-SNAPSHOT'
+
+    def strongRemoting = 'com.strongloop:strong-remoting-android:0.1.0-SNAPSHOT'
+    compile strongRemoting
+    includeJavadocs strongRemoting + ':javadoc'
+    includeSources strongRemoting + ':sources'
+
     instrumentTestCompile 'com.google.guava:guava:15.0'
 }
 
-task unpackRemotingJavadoc(type: Copy) {
-    // find dependency named 'strong-remoting-android'
-    configurations.compile.resolve().each { dep ->
-      if (dep.name.startsWith('strong-remoting-android')) {
-        def fullPath = org.apache.commons.io.FilenameUtils.getFullPath(dep.absolutePath)
-        def baseName = org.apache.commons.io.FilenameUtils.getBaseName(dep.absolutePath)
-        // add all java files from strong-remoting-android-{version}-sources.jar
-        from zipTree(fullPath + baseName + '-sources.jar')
-      }
+task unpackJavadocIncludes(type: Copy) {
+    // unpack all source dependencies
+    configurations.includeSources.resolve().each { dep ->
+        from zipTree(dep.absolutePath)
     }
-    into 'build/source/strong-remoting-android'
+    into 'build/source/javadoc-deps'
 }
 
 android.libraryVariants.all { variant ->
-    task("generate${variant.name}Javadoc", type: Javadoc, dependsOn: unpackRemotingJavadoc) {
+    task("generate${variant.name}Javadoc", type: Javadoc, dependsOn: unpackJavadocIncludes) {
         description "Generates Javadoc for $variant.name."
         source variant.javaCompile.source
-        source fileTree('build/source/strong-remoting-android').matching {
+        source fileTree('build/source/javadoc-deps').matching {
           include '**/*.java'
         }
         ext.androidJar = "${android.plugin.sdkDirectory}/platforms/${android.compileSdkVersion}/android.jar"
@@ -125,13 +130,19 @@ task dist(type: Zip, dependsOn: [
         if (dep.name.startsWith('strong-remoting-android')) {
             def baseName = org.apache.commons.io.FilenameUtils.getBaseName(dep.absolutePath)
             from(dep.absolutePath + '.properties')
-            into('src') {
-              from(new File(dep.parent, baseName + '-sources.jar'))
-            }
-            into('docs') {
-              from(new File(dep.parent, baseName + '-javadoc.jar'))
-            }
         }
+    }
+
+    configurations.includeJavadocs.resolve().each { dep ->
+      into('docs') {
+          from(dep.absolutePath)
+      }
+    }
+
+    configurations.includeSources.resolve().each { dep ->
+      into('src') {
+          from(dep.absolutePath)
+      }
     }
 
     into('src') {


### PR DESCRIPTION
Modify build.gradle to correctly locate strong-remoting-android jars when
they are downloaded from Artifactory. The previous version of build file
worked only with local maven cache.
