### PR TITLE
Make strong-remoting-android version configurable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ configurations {
 dependencies {
     compile 'org.atteo:evo-inflector:1.0.1'
 
-    def strongRemoting = 'com.strongloop:strong-remoting-android:1.+'
+    def strongRemoting = 'com.strongloop:strong-remoting-android:' + strongRemotingVersion
     compile(strongRemoting + '@jar') { transitive = true }
     subJavadocs(strongRemoting + ':javadoc') { transitive = false }
     subSources(strongRemoting + ':sources') { transitive = false }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 version=1.0.2-SNAPSHOT
+strongRemotingVersion=1+


### PR DESCRIPTION
Modify build.gradle and gradle.properties so that it's possible to edit
version of strong-remoting-android when building a release. This way
the CI build can use the latest SNAPSHOT dependency and it's still possible
to use a fixed version for a release build.

See this StackOverflow comment for more details:
http://stackoverflow.com/questions/4407055/how-do-i-stop-maven-version-ranges-from-using-snapshots#comment18858069_4407055

/cc: @cgole
