### PR TITLE
Describe how to use a different version of Android

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -81,8 +81,8 @@ Click the LoopBack app icon in the home screen to view the LoopBack Android guid
 
 **Problem**: Build fails with the message `Unable to resolve target 'android-18'`.
 
-**Resolution**: You need to install Android 18 (API 19) SDK. See [Prerequisites](#prerequisites) for instructions on how to 
-install SDK components.  
+**Resolution**: You need to install Android 4.3 (API 18) SDK. See [Prerequisites](#prerequisites) for instructions on how to
+install SDK components.
 
 If you don't want to install an older SDK and want to use the most recent one 
 (for example, Android 4.4 API 19), follow these steps:


### PR DESCRIPTION
Add "Troubleshooting" section explaining how to fix the build error
`Unable to resolve target 'android-18'`.

@crandmck Please review. This change is addressing the problem people encountered during pre-release testing on Tuesday.
