### PR TITLE
The Eclipse bundle unzips to a subdirectory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,8 @@ apply plugin: 'android-library'
 apply plugin: 'android-maven'
 apply plugin: 'signing'
 
+import org.apache.commons.io.FilenameUtils;
+
 def sonatypeRepositoryUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
 def isJenkinsBuild = System.getenv("BUILD_NUMBER")
 def isReleaseBuild = !version.contains("SNAPSHOT")
@@ -122,7 +124,7 @@ afterEvaluate { project ->
         configurations.compile.resolve().each { dep ->
             if (dep.name.startsWith('strong-remoting-android')) {
                 new File(dep.absolutePath + '.properties').withWriter { w ->
-                    def baseName = org.apache.commons.io.FilenameUtils.getBaseName(dep.absolutePath)
+                    def baseName = FilenameUtils.getBaseName(dep.absolutePath)
                     w.println('src=src/' + baseName + '-sources.jar')
                     w.println('doc=docs/' + baseName + '-javadoc.jar')
                 }
@@ -139,40 +141,53 @@ afterEvaluate { project ->
       distProperties]) {
         classifier 'eclipse-bundle'
 
-        from(androidReleaseJar.archivePath)
-        from(androidReleaseJar.archivePath.absolutePath + '.properties')
+        def root = project.name + '-' + project.version;
+
+        into(root + '/libs') {
+            from(androidReleaseJar.archivePath)
+            from(androidReleaseJar.archivePath.absolutePath + '.properties')
+        }
 
         // bundle in dependencies
         configurations.compile.resolve().each { dep ->
             // exclude jars from Android SDK
             if (dep.absolutePath.contains('/com/android/')) return
 
-            from (dep.absolutePath)
+            into(root + '/libs') {
+                from (dep.absolutePath)
 
-            // include -sources and -docs for strong-remoting-android
-            if (dep.name.startsWith('strong-remoting-android')) {
-                def baseName = org.apache.commons.io.FilenameUtils.getBaseName(dep.absolutePath)
-                from(dep.absolutePath + '.properties')
+                // include -sources and -docs for strong-remoting-android
+                if (dep.name.startsWith('strong-remoting-android')) {
+                    def baseName = FilenameUtils.getBaseName(dep.absolutePath)
+                    from(dep.absolutePath + '.properties')
+                }
             }
         }
 
         configurations.subJavadocs.resolve().each { dep ->
-          into('docs') {
-              from(dep.absolutePath)
-          }
+            into(root + '/libs/docs') {
+                from(dep.absolutePath)
+            }
         }
 
         configurations.subSources.resolve().each { dep ->
-          into('src') {
-              from(dep.absolutePath)
-          }
+            into(root + '/libs/src') {
+                from(dep.absolutePath)
+            }
         }
 
-        into('src') {
+        into(root + '/libs/docs') {
+            from(androidJavadocsJar.archivePath)
+        }
+
+        into(root + '/libs/src') {
             from(androidSourcesJar.archivePath)
         }
-        into('docs') {
-            from(androidJavadocsJar.archivePath)
+
+        into(root) {
+            from('docs/README.dist') {
+                rename 'README.dist', 'README'
+            }
         }
     }
 

--- a/docs/README.dist
+++ b/docs/README.dist
@@ -1,0 +1,13 @@
+LoopBack SDK for Android
+========================
+
+This is an Eclipse ADT bundle of LoopBack SDK for Android.
+
+Usage:
+
+    Copy content of the libs/ folder into the libs/ folder of your
+    Eclipse ADT project.
+
+Full documentation:
+
+    http://docs.strongloop.com/display/DOC/Android+SDK


### PR DESCRIPTION
Modify build.gradle to create a deeper directory structure in the ZIP bundle.

Add a short README.

This is the new structure:

loopback-android-{version}/
 +- README
 +- libs/
     +- loopback-android-{version}.jar
     +- loopback-android-{version}.jar.properties
     +- strong-remoting-android-{version}.jar
     +- strong-remoting-android-{version}.jar.properties
     +- android-async-http-1.4.3.jar
     +- evo-inflector-1.0.1.jar
 +- docs/
     +- loopback-android-{version}-javadoc.jar
     +- strong-remoting-android-{version}-javadoc.jar
 +- src/
     +- loopback-android-{version}-javadoc.jar
     +- strong-remoting-android-{version}-sources.jar

Close [PIT-188](https://strongloop.atlassian.net/browse/PIT-188).

@sam-github Please review if the new structure is a good solution of the issue you filled.
@crandmck Please review contents of `README.dist`. Note the docs URL at the end, I hope it is the right one.
