### PR TITLE
Support custom subclasses of the User model

### DIFF
--- a/src/instrumentTest/java/com/strongloop/android/loopback/test/AsyncTestCase.java
+++ b/src/instrumentTest/java/com/strongloop/android/loopback/test/AsyncTestCase.java
@@ -13,11 +13,6 @@ import com.strongloop.android.loopback.File;
 import com.strongloop.android.loopback.Model;
 import com.strongloop.android.loopback.ModelRepository;
 import com.strongloop.android.loopback.RestAdapter;
-import com.strongloop.android.loopback.UserRepository;
-import com.strongloop.android.loopback.callbacks.ListCallback;
-import com.strongloop.android.loopback.callbacks.ObjectCallback;
-import com.strongloop.android.loopback.callbacks.VoidCallback;
-import com.strongloop.android.remoting.VirtualObject;
 import com.strongloop.android.remoting.adapters.Adapter;
 import com.strongloop.android.remoting.adapters.Adapter.JsonObjectCallback;
 
@@ -65,14 +60,6 @@ public class AsyncTestCase extends ActivityTestCase {
                 notifyFinished();
             }
         };
-
-        public abstract class LoginTestCallback implements UserRepository.LoginCallback {
-
-            @Override
-            public void onError(Throwable t) {
-                notifyFailed(t);
-            }
-        }
     }
 
     public void doAsyncTest(final AsyncTest asyncTest) throws Throwable {

--- a/src/instrumentTest/java/com/strongloop/android/loopback/test/UserTest.java
+++ b/src/instrumentTest/java/com/strongloop/android/loopback/test/UserTest.java
@@ -3,34 +3,49 @@ package com.strongloop.android.loopback.test;
 import android.util.Log;
 
 import com.strongloop.android.loopback.RestAdapter;
-import com.strongloop.android.loopback.UserRepository;
 import com.strongloop.android.loopback.User;
 import com.strongloop.android.loopback.AccessToken;
+import com.strongloop.android.loopback.UserRepository;
 
-/**
- * Created by gmxtian on 2/7/14.
- */
 public class UserTest extends AsyncTestCase {
 
     private RestAdapter adapter;
-    private UserRepository userRepo;
+    private CustomerRepository customerRepo;
 
     static final private String uid = String.valueOf(new java.util.Date().getTime());
     static final private String userEmail = uid + "@test.com";
     static final private String userPassword = "testpassword";
 
+    /**
+     * Custom sub-class of User.
+     */
+    public static class Customer extends User {
+    }
+
+    /**
+     * Repository for our custom User sub-class.
+     */
+    public static class CustomerRepository extends UserRepository<Customer> {
+        public interface LoginCallback extends UserRepository.LoginCallback<Customer> {
+        }
+
+        public CustomerRepository() {
+            super("customer", null, Customer.class);
+        }
+    }
+
     @Override
     protected void setUp() throws Exception {
         super.setUp();
         adapter = createRestAdapter();
-        userRepo = adapter.createRepository(UserRepository.class);
+        customerRepo = adapter.createRepository(CustomerRepository.class);
     }
 
     // create and save
     public void testCreateSave() throws Throwable {
 
         // create user
-       final User user = userRepo.createUser(userEmail, userPassword);
+       final Customer user = customerRepo.createUser(userEmail, userPassword);
 
         assertEquals(userEmail, user.getEmail());
         assertEquals(userPassword, user.getPassword());
@@ -61,24 +76,24 @@ public class UserTest extends AsyncTestCase {
             @Override
             public void run() {
 
-                userRepo.loginUser(userEmail, userPassword,
-                    new UserRepository.LoginCallback() {
+                customerRepo.loginUser(userEmail, userPassword,
+                        new CustomerRepository.LoginCallback() {
 
-                        @Override
-                        public void onError (Throwable t){
-                            notifyFailed(t);
-                        }
+                            @Override
+                            public void onError(Throwable t) {
+                                notifyFailed(t);
+                            }
 
-                        @Override
-                        public void onSuccess (AccessToken token, User currentUser) {
-                            assertNotNull("currentUser should be not null", currentUser);
-                            assertEquals("currentUser.email", currentUser.getEmail(), userEmail);
-                            assertNotNull("accessToken should be not null", token);
-                            assertEquals("userId", token.getUserId(), currentUser.getId());
-                            Log.i("UserTest", "login id: " + currentUser.getId());
-                            notifyFinished();
-                        }
-                    });
+                            @Override
+                            public void onSuccess(AccessToken token, Customer currentUser) {
+                                assertNotNull("currentUser should be not null", currentUser);
+                                assertEquals("currentUser.email", currentUser.getEmail(), userEmail);
+                                assertNotNull("accessToken should be not null", token);
+                                assertEquals("userId", token.getUserId(), currentUser.getId());
+                                Log.i("UserTest", "login id: " + currentUser.getId());
+                                notifyFinished();
+                            }
+                        });
                }
 
         });
@@ -88,19 +103,12 @@ public class UserTest extends AsyncTestCase {
             @Override
             public void run() {
 
-                userRepo.logout(new User.Callback() {
-
+                customerRepo.logout(new VoidTestCallback() {
                     @Override
                     public void onSuccess() {
                         Log.i("UserTest", "logout succeeded");
                         notifyFinished();
                     }
-
-                    @Override
-                    public void onError(Throwable t) {
-                        notifyFailed(t);
-                    }
-
                 });
 
             }

--- a/src/main/java/com/strongloop/android/loopback/ModelRepository.java
+++ b/src/main/java/com/strongloop/android/loopback/ModelRepository.java
@@ -54,6 +54,8 @@ public class ModelRepository<T extends Model> extends RestRepository<T> {
      * Creates a new Repository, associating it with the named remote class.
      * @param className The remote class name.
      * @param nameForRestUrl The pluralized class name to use in REST transport.
+     *                       Use {@code null} for the default value, which is the plural
+     *                       form of className.
      * @param modelClass The Model class. It must have a public no-argument
      * constructor.
      */

--- a/src/main/java/com/strongloop/android/loopback/UserRepository.java
+++ b/src/main/java/com/strongloop/android/loopback/UserRepository.java
@@ -1,23 +1,46 @@
 package com.strongloop.android.loopback;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import org.json.JSONObject;
-
-import com.strongloop.android.loopback.Model.Callback;
+import com.strongloop.android.loopback.callbacks.VoidCallback;
 import com.strongloop.android.remoting.JsonUtil;
 import com.strongloop.android.remoting.adapters.Adapter;
 import com.strongloop.android.remoting.adapters.RestContract;
 import com.strongloop.android.remoting.adapters.RestContractItem;
 
+import org.json.JSONObject;
+
+import java.util.HashMap;
+import java.util.Map;
+
 /**
- * Locally create or retrieves a user type from the server, encapsulating
- * the name of the user type for easy {@link User} creation, discovery, and
- * management.
+ * A base class implementing {@link ModelRepository} for the built-in User type.
+ * <p>
+ * <pre>{@code
+ * UserRepository<MyUser> userRepo = new UserRepository<MyUser>("user", MyUser.class);
+ * }</pre>
+ * <p>
+ * Most application are extending the built-in User model and adds new properties
+ * like address, etc. You should create your own Repository class
+ * by extending this base class in such case.
+ * <p>
+ * <pre>{@code
+ * public class Customer extends User {
+ *   // your custom properties and prototype (instance) methods
+ * }
+ *
+ * public class CustomerRepository extends UserRepository<Customer> {
+ *     public interface LoginCallback extends LoginCallback<Customer> {
+ *     }
+ *
+ *     public CustomerRepository() {
+ *         super("customer", null, Customer.class);
+ *     }
+ *
+ *     // your custom static methods
+ * }
+ * }</pre>
  */
-public class UserRepository extends ModelRepository<User> {
-    
+public class UserRepository<U extends User> extends ModelRepository<U> {
+
     private AccessTokenRepository accessTokenRepository;
 
     private RestAdapter getRestAdapter() {
@@ -33,47 +56,62 @@ public class UserRepository extends ModelRepository<User> {
     }
 
     /**
-     * Creates a new UserRepository, associating it with the static {@link User}
-     * model class and the user class name.
+     * Creates a new UserRepository, associating it with
+     * the static {@code U} user class and the user class name.
+     * @param className The remote class name.
+     * @param userClass The User (sub)class. It must have a public no-argument constructor.
      */
-    public UserRepository() {
-        super("user", User.class);
+    public UserRepository(String className, Class<U> userClass) {
+        super(className, null, userClass);
     }
-    
+
+    /**
+     * Creates a new UserRepository, associating it with
+     * the static {@code U} user class and the user class name.
+     * @param className The remote class name.
+     * @param nameForRestUrl The pluralized class name to use in REST transport.
+     *                       Use {@code null} for the default value, which is the plural
+     *                       form of className.
+     * @param userClass The User (sub)class. It must have a public no-argument constructor.
+     */
+    public UserRepository(String className, String nameForRestUrl, Class<U> userClass) {
+        super(className, nameForRestUrl, userClass);
+    }
+
     /**
      * Callback passed to loginUser to receive success and newly created
-     * {@link User} instance or thrown error. 
+     * {@code U} user instance or thrown error.
      */
-    public interface LoginCallback {
-        public void onSuccess(AccessToken token, User currentUser);
+    public interface LoginCallback<U> {
+        public void onSuccess(AccessToken token, U currentUser);
         public void onError(Throwable t);
     }
 
     /**
-     * Creates a {@link User} given an email and a password.
+     * Creates a {@code U} user instance given an email and a password.
      * @param email
      * @param password
-     * @return A {@link User}.
+     * @return A {@code U} user instance.
      */
-    public User createUser(String email, String password)     {
+    public U createUser(String email, String password)     {
         Map<String, Object> map = new HashMap<String, Object>();
         map.put("email", email);
         map.put("password", password);
-        User user = createModel(map);
+        U user = createObject(map);
         return user;
     }
-    
+
      /**
-     * Creates a {@link RestContract} representing the user type's custom
-     * routes. Used to extend an {@link Adapter} to support user. Calls
+     * Creates a {@link com.strongloop.android.remoting.adapters.RestContract} representing the user type's custom
+     * routes. Used to extend an {@link com.strongloop.android.remoting.adapters.Adapter} to support user. Calls
      * super {@link ModelRepository} createContract first.
      *
-     * @return A {@link RestContract} for this model type.
+     * @return A {@link com.strongloop.android.remoting.adapters.RestContract} for this model type.
      */
-     
+
     public RestContract createContract() {
         RestContract contract = super.createContract();
-        
+
         String className = getClassName();
 
         contract.addItem(new RestContractItem("/" + getNameForRestUrl() + "/login?include=user", "POST"),
@@ -82,35 +120,36 @@ public class UserRepository extends ModelRepository<User> {
                 className + ".logout");
         return contract;
     }
-    
+
     /**
-     * Creates a new {@link User} given the email, password and optional parameters.
+     * Creates a new {@code U} user given the email, password and optional parameters.
      * @param email - user email
      * @param password - user password
      * @param parameters - optional parameters
-     * @return A new {@link User}
+     * @return A new {@code U} user instance.
      */
-    public User createUser(String email, String password, 
+    public U createUser(String email, String password,
             Map<String, ? extends Object> parameters) {
 
         HashMap<String, Object> allParams = new HashMap<String, Object>();
         allParams.putAll(parameters);
         allParams.put("email", email);
         allParams.put("password", password);
-        User user = createModel(allParams);
-        
-        return user;    
+        U user = createObject(allParams);
+
+        return user;
     }
-        
+
     /**
-     * Login a user given an email and password. Creates a User model if successful.
+     * Login a user given an email and password.
+     * Creates a {@link AccessToken} and {@code U} user models if successful.
      * @param email - user email
      * @param password - user password
      * @param callback - success/error callback
      */
-    public void loginUser(String email, String password, 
-            final LoginCallback callback) {
-        
+    public void loginUser(String email, String password,
+            final LoginCallback<U> callback) {
+
         HashMap<String, Object> params = new HashMap<String, Object>();
         params.put("email",  email);
         params.put("password",  password);
@@ -126,12 +165,12 @@ public class UserRepository extends ModelRepository<User> {
                     @Override
                     public void onSuccess(JSONObject response) {
                         AccessToken token = getAccessTokenRepository()
-                                .createModel(JsonUtil.fromJson(response));
+                                .createObject(JsonUtil.fromJson(response));
                         getRestAdapter().setAccessToken(token.getId().toString());
 
                         JSONObject userJson = response.optJSONObject("user");
-                        User user = userJson != null
-                                ? createModel(JsonUtil.fromJson(userJson))
+                        U user = userJson != null
+                                ? createObject(JsonUtil.fromJson(userJson))
                                 : null;
 
                         callback.onSuccess(token, user);
@@ -140,14 +179,14 @@ public class UserRepository extends ModelRepository<User> {
     }
 
     /**
-     * Logs the current User out of the server and removes the access
+     * Logs the current user out of the server and removes the access
      * token from the system.
      * <p>
      * @param callback The callback to be executed when finished.
      */
-     
-    public void logout(final Callback callback) {
-        
+
+    public void logout(final VoidCallback callback) {
+
         invokeStaticMethod("logout", null,
                 new Adapter.Callback() {
 
@@ -164,5 +203,5 @@ public class UserRepository extends ModelRepository<User> {
             }
         });
     }
-    
+
 }

--- a/test-server/index.js
+++ b/test-server/index.js
@@ -46,7 +46,7 @@ Widget.destroyAll(function () {
 
 app.model(loopback.AccessToken);
 
-app.model('User', {
+app.model('Customer', {
   options: {
     base: 'User',
     relations: {


### PR DESCRIPTION
- Provide API supporting custom model classes extending the built-in User
  model.
- Move most of `UserRepository` to `UserRepositoryBase<U>`, where `U`
  is the generic User subclass.
- Implement `UserRepository` as a thin wrapper extending
  `UserRepositoryBase<User>`.
- Improve javadoc comments.

/to: @raymondfeng please review.
