### PR TITLE
Fix FileTest and test-server storage setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ proguard/
 .DS_Store
 
 node_modules
+/test-server/storage/

--- a/src/androidTest/java/com/strongloop/android/loopback/test/FileTest.java
+++ b/src/androidTest/java/com/strongloop/android/loopback/test/FileTest.java
@@ -229,17 +229,15 @@ public class FileTest extends AsyncTestCase {
                     @Override
                     public void onSuccess(File file) {
                         assertEquals(local.getName(), file.getName());
-                        try {
-                            byte[] content = download(container, "a-file");
-                            MoreAsserts.assertEquals(binaryData, content);
-                        } catch (Throwable error) {
-                            notifyFailed(error);
-                        }
                         notifyFinished();
                     }
                 });
             }
         });
+
+        Log.i(TAG, "Downloading the uploaded file");
+        byte[] content = download(container, local.getName());
+        MoreAsserts.assertEquals(binaryData, content);
     }
 
     public void testFileDownloadToLocalFile() throws Throwable {
@@ -268,6 +266,7 @@ public class FileTest extends AsyncTestCase {
     private byte[] download(final Container container, final String fileName)
             throws Throwable {
         final List<byte[]> ref = new ArrayList<byte[]>(1);
+        ref.add(null);
 
         await(new AsyncTask() {
             @Override

--- a/test-server/index.js
+++ b/test-server/index.js
@@ -64,11 +64,14 @@ app.dataSource('mail', { connector: 'mail', defaultForType: 'mail' });
 loopback.autoAttach();
 
 // storage service
-
+var fs = require('fs');
+var storage = path.join(__dirname, 'storage');
+if (!fs.existsSync(storage))
+  fs.mkdirSync(storage);
 app.dataSource('storage', {
   connector: require('loopback-storage-service'),
   provider: 'filesystem',
-  root: path.join(__dirname, 'storage')
+  root: storage
 });
 
 var Container = app.dataSources.storage.createModel('container');


### PR DESCRIPTION
Rework testFileUploadFromLocalFile() to call methods on the correct
thread.

Fix incorrect usage of ArrayList in download().

Fix server-test to create the storage directory on startup.

Add the storage directory to .gitignore.

/to @raymondfeng FYI.
