### PR TITLE
docs: improve the content displayed on the web

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -4,6 +4,6 @@
     "/api": "docs/api"
   },
   "content": [
-    "README.md"
+    "docs/index.md"
   ]
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,3 @@
+Please see the LoopBack
+[Android SDK API Reference](http://apidocs.strongloop.com/loopback-sdk-android/api/index.html).
+


### PR DESCRIPTION
This commit makes the apidocs consistent with other modules by removing README from the list of files processed by strong-docs. This fix removes the duplicated entry "LoopBack Android SDK" from the left sidebar.

/to @ritch @crandmck please review
/cc @sumitha 
