### PR TITLE
docs/index: use a relative link to javadoc pages

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,3 @@
 Please see the LoopBack
-[Android SDK API Reference](http://apidocs.strongloop.com/loopback-sdk-android/api/index.html).
+[Android SDK API Reference](api/index.html).
 


### PR DESCRIPTION
The absolute URL breaks API doc versioning, since all versions are
pointing to the same URL. With the relative link in place, browser
will include the version in the request URL.

Base URL:
  http://apidocs.strongloop.com/loopback-sdk-android/v/1.4.1/

Relative link:
  api/index.html

Result:
  http://apidocs.strongloop.com/loopback-sdk-android/v/1.4.1/api/index.html

/cc @ritch @crandmck 

The change requires https://github.com/strongloop-internal/docs.strongloop.com/pull/41
