### PR TITLE
Support android studio 1.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,17 +34,17 @@ repositories {
 
 android {
     compileSdkVersion 21
-    buildToolsVersion "21.0.2"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 8
-        targetSdkVersion 20
+        targetSdkVersion 21
     }
 }
 
 dependencies {
     compile 'org.atteo:evo-inflector:1.2'
-    compile 'com.google.guava:guava:17.0'
+    compile 'com.google.guava:guava:18.0'
     compile 'com.loopj.android:android-async-http:1.4.5'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,5 @@
 group = 'com.strongloop';
 
-logger.info('**JVM VERSION** ' + org.gradle.internal.jvm.Jvm.current())
-
 buildscript {
   repositories {
       mavenCentral()
@@ -17,12 +15,14 @@ apply plugin: 'com.android.library'
 apply plugin: 'android-maven'
 apply plugin: 'signing'
 
-import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.io.FilenameUtils
+import org.gradle.internal.jvm.Jvm;
 
 def sonatypeRepositoryUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-def isJenkinsBuild = System.getenv("BUILD_NUMBER")
 def isReleaseBuild = !version.contains("SNAPSHOT")
 def shouldPublishToMavenCentral = isReleaseBuild
+
+logger.info('**JVM VERSION** ' + Jvm.current())
 
 repositories {
     mavenLocal()

--- a/build.gradle
+++ b/build.gradle
@@ -7,9 +7,9 @@ buildscript {
       mavenCentral()
   }
   dependencies {
-      classpath 'com.android.tools.build:gradle:0.14.2'
+      classpath 'com.android.tools.build:gradle:1.1.0'
       classpath 'org.apache.commons:commons-io:1.3.2'
-      classpath 'com.github.dcendents:android-maven-plugin:1.0'
+      classpath 'com.github.dcendents:android-maven-plugin:1.2'
   }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Nov 18 18:51:36 CET 2014
+#Tue Mar 31 13:40:28 CEST 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip


### PR DESCRIPTION
Upgrade build:

 - Gradle 2.2
 - android gradle build tools 1.1.0
 - android-maven-plugin 1.2

Upgrade other dependencies too, clean up build.gradle as suggested by Android Studio.

Close #67