### PR TITLE
Use loopback 3.0-alpha

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "async": "~0.9.0",
     "express": "^4.9.8",
-    "loopback": "^2.5.0",
+    "loopback": "^3.0.0-alpha.5",
     "loopback-component-push": "1.x",
     "loopback-component-storage": "1.x",
     "morgan": "^1.4.0",


### PR DESCRIPTION
From Miroslav:
>The Android SDK does not run any tests on the CI, I think having two branches (master and loopback-2.x) is pointless. It should be enough to upgrade the master branch to depend on loopback 3.0-alpha.

No ned to create a `loopback-2.x` branch for this repo.

/to: @superkhau 
